### PR TITLE
feat: add request to validate corporation number from api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-slot": "^1.1.2",
+        "@tanstack/react-query": "^5.66.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.474.0",
@@ -1765,6 +1766,32 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.66.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.66.0.tgz",
+      "integrity": "sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.66.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.66.0.tgz",
+      "integrity": "sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.66.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.2",
+    "@tanstack/react-query": "^5.66.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.474.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
+
 import localFont from 'next/font/local'
 import './globals.css'
+import { Providers } from '@/components/providers'
 
 const geistSans = localFont({
   src: './fonts/GeistVF.woff',
@@ -28,7 +30,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   )

--- a/src/components/onboarding-form.test.tsx
+++ b/src/components/onboarding-form.test.tsx
@@ -2,10 +2,28 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { OnboardingForm } from './onboarding-form'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 0,
+      },
+    },
+  })
+
+  const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  TestWrapper.displayName = 'TestWrapper'
+  return TestWrapper
+}
 
 describe('OnboardingForm', () => {
   it('renders all form fields', () => {
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     expect(screen.getByLabelText(/first name/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/last name/i)).toBeInTheDocument()
@@ -15,7 +33,7 @@ describe('OnboardingForm', () => {
   })
 
   it('shows correct default values', () => {
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     expect(screen.getByLabelText(/phone number/i)).toHaveValue('+1')
     expect(screen.getByLabelText(/first name/i)).toHaveValue('')
@@ -24,7 +42,7 @@ describe('OnboardingForm', () => {
   })
 
   it('shows validation errors when form submitted empty', async () => {
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     const submitButton = screen.getByRole('button', { name: /submit/i })
     fireEvent.click(submitButton)
@@ -40,7 +58,7 @@ describe('OnboardingForm', () => {
   })
 
   it('shows validation errors for empty first name', async () => {
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     const firstNameInput = screen.getByLabelText(/first name/i)
 
@@ -52,7 +70,7 @@ describe('OnboardingForm', () => {
   })
 
   it('shows validation errors for empty last name', async () => {
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     const lastNameInput = screen.getByLabelText(/last name/i)
 
@@ -65,7 +83,7 @@ describe('OnboardingForm', () => {
 
   it('shows validation errors when first name exceed 50 characters', async () => {
     const user = userEvent.setup()
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     const longString = 'a'.repeat(51)
 
@@ -82,7 +100,7 @@ describe('OnboardingForm', () => {
 
   it('shows validation errors when last name exceed 50 characters', async () => {
     const user = userEvent.setup()
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     const longString = 'a'.repeat(51)
 
@@ -99,7 +117,7 @@ describe('OnboardingForm', () => {
 
   it('validates phone number format', async () => {
     const user = userEvent.setup()
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     const phoneInput = screen.getByLabelText(/phone number/i)
     await user.clear(phoneInput)
@@ -116,7 +134,7 @@ describe('OnboardingForm', () => {
 
   it('validates corporation number format', async () => {
     const user = userEvent.setup()
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     const corporationInput = screen.getByLabelText(/corporation number/i)
     await user.type(corporationInput, '12345')
@@ -124,7 +142,9 @@ describe('OnboardingForm', () => {
     fireEvent.blur(corporationInput)
 
     await waitFor(() => {
-      expect(screen.getByText(/must be exactly 9 digits/i)).toBeInTheDocument()
+      expect(
+        screen.getByText(/Invalid corporation number/i)
+      ).toBeInTheDocument()
     })
   })
 
@@ -133,7 +153,7 @@ describe('OnboardingForm', () => {
     const user = userEvent.setup()
     const consoleSpy = vi.spyOn(console, 'log')
 
-    render(<OnboardingForm />)
+    render(<OnboardingForm />, { wrapper: createWrapper() })
 
     await user.type(screen.getByLabelText(/first name/i), 'John')
     await user.type(screen.getByLabelText(/last name/i), 'Doe')

--- a/src/components/onboarding-form.tsx
+++ b/src/components/onboarding-form.tsx
@@ -17,8 +17,15 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form'
+import { useEffect, useState } from 'react'
+import { useValidateCorporationNumber } from '@/lib/queries'
 
 export const OnboardingForm = () => {
+  const [corpNumberToValidate, setCorpNumberToValidate] = useState('')
+
+  const { data: validationResult, isLoading: validationIsLoading } =
+    useValidateCorporationNumber(corpNumberToValidate)
+
   const form = useForm<OnboardingFormData>({
     resolver: zodResolver(onboardingSchema),
     defaultValues: {
@@ -30,10 +37,33 @@ export const OnboardingForm = () => {
     mode: 'onBlur',
   })
 
+  useEffect(() => {
+    if (validationResult) {
+      if (!validationResult.valid) {
+        console.log('validationResult - invalid')
+        form.setError(
+          'corporationNumber',
+          {
+            type: 'manual',
+            message: validationResult.message,
+          },
+          {
+            shouldFocus: true,
+          }
+        )
+      } else {
+        console.log('validationResult - valid')
+        form.clearErrors('corporationNumber')
+      }
+    }
+  }, [validationResult, form])
+
   const onSubmit = (data: OnboardingFormData) => {
     console.log(data)
     // Handle form submission
   }
+
+  console.log('FORM ERRORS', form.formState.errors)
 
   return (
     <div className="container mx-auto">
@@ -54,7 +84,7 @@ export const OnboardingForm = () => {
                   control={form.control}
                   name="firstName"
                   render={({ field }) => (
-                    <FormItem className="flex flex-col w-full">
+                    <FormItem>
                       <FormLabel>First Name</FormLabel>
                       <FormControl>
                         <Input {...field} />
@@ -70,7 +100,7 @@ export const OnboardingForm = () => {
                   control={form.control}
                   name="lastName"
                   render={({ field }) => (
-                    <FormItem className="flex flex-col w-full">
+                    <FormItem>
                       <FormLabel>Last Name</FormLabel>
                       <FormControl>
                         <Input {...field} />
@@ -87,7 +117,7 @@ export const OnboardingForm = () => {
                 control={form.control}
                 name="phoneNumber"
                 render={({ field }) => (
-                  <FormItem className="flex flex-col w-full">
+                  <FormItem>
                     <FormLabel>Phone Number</FormLabel>
                     <FormControl>
                       <Input {...field} />
@@ -99,21 +129,35 @@ export const OnboardingForm = () => {
                 )}
               />
 
-              <FormField
-                control={form.control}
-                name="corporationNumber"
-                render={({ field }) => (
-                  <FormItem className="flex flex-col w-full">
-                    <FormLabel>Corporation Number</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <div className="h-3">
-                      <FormMessage />
-                    </div>
-                  </FormItem>
+              <div className="relative">
+                <FormField
+                  control={form.control}
+                  name="corporationNumber"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Corporation Number</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          onBlur={() => {
+                            if (field.value) {
+                              setCorpNumberToValidate(field.value)
+                            }
+                          }}
+                        />
+                      </FormControl>
+                      <div className="h-3">
+                        <FormMessage />
+                      </div>
+                    </FormItem>
+                  )}
+                />
+                {validationIsLoading && (
+                  <div className="absolute right-1/2 top-1/2 -translate-y-1/2">
+                    <span className="animate-spin">⌛</span>
+                  </div>
                 )}
-              />
+              </div>
 
               <Button type="submit" className="w-full">
                 Submit

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,0 +1,14 @@
+'use client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const queryClient = new QueryClient()
+
+export const Providers = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) => {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -80,7 +80,11 @@ const FormItem = React.forwardRef<
 
   return (
     <FormItemContext.Provider value={{ id }}>
-      <div ref={ref} className={cn('space-y-2', className)} {...props} />
+      <div
+        ref={ref}
+        className={cn('space-y-2 flex flex-col w-full', className)}
+        {...props}
+      />
     </FormItemContext.Provider>
   )
 })

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,2 @@
+export const CORPORATION_NUMBER_API_URL =
+  'https://fe-hometask-api.dev.vault.tryvault.com/corporation-number'

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+import { CORPORATION_NUMBER_API_URL } from './constants'
+
+type ValidateCorporationNumberResponse =
+  | {
+      valid: true
+      corporationNumber: string
+    }
+  | {
+      valid: false
+      message: string
+    }
+
+const validateCorporationNumber = async (
+  value: string
+): Promise<ValidateCorporationNumberResponse> => {
+  const response = await fetch(`${CORPORATION_NUMBER_API_URL}/${value}`)
+  return response.json()
+}
+
+export const useValidateCorporationNumber = (corpNumberToValidate: string) => {
+  return useQuery({
+    queryKey: ['corporationNumber', corpNumberToValidate],
+    queryFn: () => validateCorporationNumber(corpNumberToValidate),
+    enabled: !!corpNumberToValidate,
+    staleTime: 1000 * 60 * 5,
+  })
+}


### PR DESCRIPTION
- Add Tanstack Query to cache results
- Add React Query provider
- Fix the tests to use mock React Query Provider
- Update test for corporation number to expect a proper message from the server
- Add the queries to reach valiation API with a proper corproation number
- If response returned valid false set the message from the response to react hook forms error state